### PR TITLE
Support newer ghc: allow attoparsec 0.14.x

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -14,7 +14,7 @@ extra-source-files:
 - ChangeLog.md
 
 dependencies:
-- attoparsec >= 0.13.2.0  && < 0.14.0.0
+- attoparsec >= 0.13.2.0  && < 0.15.0.0
 - base       >= 4.7       && < 5
 - bytestring >= 0.10.12.0 && < 0.12.0.0
 - hidapi     >= 0.1.7     && < 0.2.0

--- a/switch.cabal
+++ b/switch.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,7 +39,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      attoparsec >=0.13.2.0 && <0.14.0.0
+      attoparsec >=0.13.2.0 && <0.15.0.0
     , base >=4.7 && <5
     , bytestring >=0.10.12.0 && <0.12.0.0
     , hidapi >=0.1.7 && <0.2.0
@@ -57,7 +57,7 @@ test-suite cube
   build-depends:
       GPipe
     , GPipe-GLFW
-    , attoparsec >=0.13.2.0 && <0.14.0.0
+    , attoparsec >=0.13.2.0 && <0.15.0.0
     , base >=4.7 && <5
     , bytestring >=0.10.12.0 && <0.12.0.0
     , hidapi >=0.1.7 && <0.2.0
@@ -76,7 +76,7 @@ test-suite leftJoyCon
       test/LeftJoyCon
   ghc-options: -Wall
   build-depends:
-      attoparsec >=0.13.2.0 && <0.14.0.0
+      attoparsec >=0.13.2.0 && <0.15.0.0
     , base >=4.7 && <5
     , bytestring >=0.10.12.0 && <0.12.0.0
     , hidapi >=0.1.7 && <0.2.0
@@ -94,7 +94,7 @@ test-suite proController
       test/ProController
   ghc-options: -Wall
   build-depends:
-      attoparsec >=0.13.2.0 && <0.14.0.0
+      attoparsec >=0.13.2.0 && <0.15.0.0
     , base >=4.7 && <5
     , bytestring >=0.10.12.0 && <0.12.0.0
     , hidapi >=0.1.7 && <0.2.0
@@ -112,7 +112,7 @@ test-suite rightJoyCon
       test/RightJoyCon
   ghc-options: -Wall
   build-depends:
-      attoparsec >=0.13.2.0 && <0.14.0.0
+      attoparsec >=0.13.2.0 && <0.15.0.0
     , base >=4.7 && <5
     , bytestring >=0.10.12.0 && <0.12.0.0
     , hidapi >=0.1.7 && <0.2.0


### PR DESCRIPTION
Newer ghc versions come with a bytestring-version (e.g. ghc-9.4.4 comes with  bytestring-0.11.3.1) not supported by attoparsec 0.13.
This PR bumps the maximum attoparsec-version, so it can be build with newer ghc-versions as well.

Note:
Tests can't be build/run, due to dependency-issues with GPipe and I couldn't find a new version that works.